### PR TITLE
fix(security): patch esbuild RCE vulnerability (GHSA-gv7w-rqvm-qjhr)

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -34,5 +34,8 @@
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",
     "vite": "^4.3.9"
+  },
+  "overrides": {
+    "esbuild": ">=0.28.1"
   }
 }


### PR DESCRIPTION
## Summary

Patches the high-severity RCE vulnerability in `esbuild` ([GHSA-gv7w-rqvm-qjhr](https://github.com/advisories/GHSA-gv7w-rqvm-qjhr)).

**Vulnerable range:** `>= 0.17.0, < 0.28.1`
**Fix:** `>= 0.28.1`

The esbuild Deno module downloads native binaries without integrity verification when `NPM_CONFIG_REGISTRY` is set, enabling RCE via a malicious registry.

## Changes

Added npm override to pin `esbuild` to `>=0.28.1`

## Notes
- After merging, run `cd api && npm install` to regenerate the lockfile if it was not included in this PR.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/zerebel/blog-api/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->